### PR TITLE
remove permute

### DIFF
--- a/loss/loss.py
+++ b/loss/loss.py
@@ -31,7 +31,7 @@ class Loss(nn.Module):
         B,N,C=pcd.shape[0],pcd.shape[1],pcd.shape[2]
         npoint=int(N*0.05)
         loss=0
-        further_point_idx = pn2_utils.furthest_point_sample(pcd.permute(0, 2, 1).contiguous(), npoint)
+        further_point_idx = pn2_utils.furthest_point_sample(pcd.contiguous(), npoint)
         new_xyz = pn2_utils.gather_operation(pcd.permute(0, 2, 1).contiguous(), further_point_idx)  # B,C,N
         for p in percentage:
             nsample=int(N*p)


### PR DESCRIPTION
I found a problem in your code. If you use (B, N, C) as the point cloud format. You shouldn't permute the pcd of FPS input. According to your code, I tried to output the FPS result. It shows several valid index and most index are 0. It's not reasonable. When I changed to my version, it can correctly produce valid index. Also, I visionlized the point cloud after FPS. It keep the shape of original point cloud, which is consistant with description of FPS.
Finnally, Thank you for publishing your code here. That really helps me much!